### PR TITLE
Fixed import error that occurs when using the library in next.js 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awoken-bible-reference",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Bible verse reference parser, generator and manipulator",
   "main": "dist/awoken-ref.cjs.js",
   "module": "dist/awoken-ref.esm.mjs",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/awoken-ref.esm.mjs",
-        "types": "./dist/types/index.d.ts"
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/awoken-ref.esm.mjs"
       },
       "require": {
-        "default": "./dist/awoken-ref.cjs.js",
-        "types": "./dist/types/index.d.ts"
+        
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/awoken-ref.cjs.js"
       }
     },
     "./browser": "./dist/browser/awoken-ref.min.js"


### PR DESCRIPTION
The error that occurs when using the AwokeRef in a next.js component is:  Module not found: Default condition should be last one

The root cause is an out-of-order declaration in the package.json file. Silly I know, but just swapping the order of the declarations in the file fixes the problem. 

Great library by the way. Thanks for doing all the heavy lifting.  